### PR TITLE
fix: Add required mcp dep to requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,6 @@ Open your computer's Terminal (Mac) or Command Prompt (Windows):
 
    # OR using standard pip:
    pip install -r requirements.txt
-   
-   # If you encounter any issues with the MCP package, install it separately:
-   pip install mcp
    ```
 
    **If you get "pip not found" error:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 google-api-python-client>=2.0.0
 oauth2client>=4.1.3
 google-auth>=2.0.0
+mcp>=1.6.0


### PR DESCRIPTION
Without `mcp` in `requirements.txt` there is an error during initialization:
```
2025-04-07T13:13:05.541Z [gscServer] [info] Initializing server...
2025-04-07T13:13:05.548Z [gscServer] [info] Server started and connected successfully
2025-04-07T13:13:05.550Z [gscServer] [info] Message from client: {"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"claude-ai","version":"0.1.0"}},"jsonrpc":"2.0","id":0}
Traceback (most recent call last):
  File "/Users/zizzfizzix/Code/mcp-gsc/gsc_server.py", line 13, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp'
2025-04-07T13:13:07.117Z [gscServer] [info] Server transport closed
2025-04-07T13:13:07.117Z [gscServer] [info] Client transport closed
2025-04-07T13:13:07.117Z [gscServer] [info] Server transport closed unexpectedly, this is likely due to the process exiting early. If you are developing this MCP server you can add output to stderr (i.e. `console.error('...')` in JavaScript, `print('...', file=sys.stderr)` in python) and it will appear in this log.
2025-04-07T13:13:07.118Z [gscServer] [error] Server disconnected. For troubleshooting guidance, please visit our [debugging documentation](https://modelcontextprotocol.io/docs/tools/debugging) {"context":"connection"}
2025-04-07T13:13:07.118Z [gscServer] [info] Client transport closed
```