### PR TITLE
feat: Implement OAuth flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ env/
 service_account_credentials.json
 credentials.json
 token.json
+client_secret*.json
 
 # Editor-specific files
 .vscode/

--- a/README.md
+++ b/README.md
@@ -56,10 +56,49 @@ Here's what you can ask Claude to do once you've set up this integration:
 
 Before using this tool, you'll need to create API credentials that allow Claude to access your GSC data:
 
-1. Create a Google Cloud account if you don't have one and access the [Google Cloud Console](https://console.cloud.google.com/)
-2. Set up a service account (like a special user for API access)
-3. Download the credentials file (a JSON file)
-4. Grant this service account access to your GSC properties
+#### Authentication Options
+
+The tool supports two authentication methods:
+
+##### 1. OAuth Authentication (Recommended)
+
+This method allows you to authenticate with your own Google account, which is often more convenient than using a service account. It will have access to the same resources you normally do.
+
+Set `GSC_SKIP_OAUTH` to "true", "1", or "yes" to skip OAuth authentication and use only service account authentication
+
+###### Setup Instructions:
+
+1. Go to the [Google Cloud Console](https://console.cloud.google.com/) and create a Google Cloud account if you don't have one
+2. Create a new project or select an existing one
+3. [Enable the Search Console API](https://console.cloud.google.com/apis/library/searchconsole.googleapis.com) for your project
+4. [Add scope](https://console.cloud.google.com/auth/scopes) `https://www.googleapis.com/auth/webmasters` to your project
+5. Go to the ["Credentials" page](https://console.cloud.google.com/apis/credentials)
+6. Click "Create Credentials" and select "OAuth client ID"
+7. Configure the OAuth consent screen
+8. For application type, select "Desktop app"
+9. Give your OAuth client a name and click "Create"
+10. Download the client secrets JSON file (it will be named something like `client_secrets.json`)
+11. Place this file in the same directory as the script or set the `GSC_OAUTH_CLIENT_SECRETS_FILE` environment variable to point to its location
+
+When you run the tool for the first time with OAuth authentication, it will open a browser window asking you to sign in to your Google account and authorize the application. After authorization, the tool will save the token for future use.
+
+##### 2. Service Account Authentication
+
+This method uses a service account, which is useful for automated scripts or when you don't want to use your personal Google account. This requires adding the service account as a user in Google Search Console.
+
+###### Setup Instructions:
+
+1. Go to the [Google Cloud Console](https://console.cloud.google.com/) and create a Google Cloud account if you don't have one
+2. Create a new project or select an existing one
+3. [Enable the Search Console API](https://console.cloud.google.com/apis/library/searchconsole.googleapis.com) for your project
+4. Go to the ["Credentials" page](https://console.cloud.google.com/apis/credentials)
+5. Click "Create Credentials" and select "Service Account"
+6. Fill in the service account details and click "Create"
+7. Click on the newly created service account
+8. Go to the "Keys" tab and click "Add Key" > "Create new key"
+9. Select JSON format and click "Create"
+10. Download the key file and save it as `service_account_credentials.json` in the same directory as the script or set the `GSC_CREDENTIALS_PATH` environment variable to point to its location
+11. Add your service account email address to appropriate Search Console properties
 
 **🎬 Watch this beginner-friendly tutorial on Youtube:**
 
@@ -171,7 +210,9 @@ When you see `(.venv)` at the beginning of your command prompt, it means the vir
    notepad %APPDATA%\Claude\claude_desktop_config.json
    ```
 
-4. Add the following text (this tells Claude how to connect to GSC):
+4. Add the following configuration text (this tells Claude how to connect to GSC):
+
+#### OAuth authentication (using your own account)
 
    ```json
    {
@@ -180,7 +221,24 @@ When you see `(.venv)` at the beginning of your command prompt, it means the vir
          "command": "/FULL/PATH/TO/-main/.venv/bin/python",
          "args": ["/FULL/PATH/TO/mcp-gsc-main/gsc_server.py"],
          "env": {
-           "GSC_CREDENTIALS_PATH": "/FULL/PATH/TO/service_account_credentials.json"
+           "GSC_OAUTH_CLIENT_SECRETS_FILE": "/FULL/PATH/TO/client_secrets.json"
+         }
+       }
+     }
+   }
+   ```
+
+#### Service account authentication
+
+   ```json
+   {
+     "mcpServers": {
+       "gscServer": {
+         "command": "/FULL/PATH/TO/-main/.venv/bin/python",
+         "args": ["/FULL/PATH/TO/mcp-gsc-main/gsc_server.py"],
+         "env": {
+           "GSC_CREDENTIALS_PATH": "/FULL/PATH/TO/service_account_credentials.json",
+           "GSC_SKIP_OAUTH": "true"
          }
        }
      }

--- a/gsc_server.py
+++ b/gsc_server.py
@@ -6,6 +6,8 @@ from datetime import datetime, timedelta
 import google.auth
 from google.auth.transport.requests import Request
 from google.oauth2 import service_account
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
@@ -26,13 +28,33 @@ POSSIBLE_CREDENTIAL_PATHS = [
     # Add any other potential paths here
 ]
 
+# OAuth client secrets file path
+OAUTH_CLIENT_SECRETS_FILE = os.environ.get("GSC_OAUTH_CLIENT_SECRETS_FILE")
+if not OAUTH_CLIENT_SECRETS_FILE:
+    OAUTH_CLIENT_SECRETS_FILE = os.path.join(SCRIPT_DIR, "client_secrets.json")
+
+# Token file path for storing OAuth tokens
+TOKEN_FILE = os.path.join(SCRIPT_DIR, "token.json")
+
+# Environment variable to skip OAuth authentication
+SKIP_OAUTH = os.environ.get("GSC_SKIP_OAUTH", "").lower() in ("true", "1", "yes")
+
 SCOPES = ["https://www.googleapis.com/auth/webmasters.readonly"]
 
 def get_gsc_service():
     """
     Returns an authorized Search Console service object.
-    Checks for credentials in environment variable first, then fallback locations.
+    First tries OAuth authentication, then falls back to service account.
     """
+    # Try OAuth authentication first if not skipped
+    if not SKIP_OAUTH:
+        try:
+            return get_gsc_service_oauth()
+        except Exception as e:
+            # If OAuth fails, try service account
+            pass
+    
+    # Try service account authentication
     for cred_path in POSSIBLE_CREDENTIAL_PATHS:
         if cred_path and os.path.exists(cred_path):
             try:
@@ -43,12 +65,46 @@ def get_gsc_service():
             except Exception as e:
                 continue  # Try the next path if this one fails
     
-    # If we get here, none of the paths worked
+    # If we get here, none of the authentication methods worked
     raise FileNotFoundError(
-        f"Credentials file not found. Please set the GSC_CREDENTIALS_PATH environment variable "
-        f"or place credentials file in one of these locations: "
+        f"Authentication failed. Please either:\n"
+        f"1. Set up OAuth by placing a client_secrets.json file in the script directory, or\n"
+        f"2. Set the GSC_CREDENTIALS_PATH environment variable or place a service account credentials file in one of these locations: "
         f"{', '.join([p for p in POSSIBLE_CREDENTIAL_PATHS[1:] if p])}"
     )
+
+def get_gsc_service_oauth():
+    """
+    Returns an authorized Search Console service object using OAuth.
+    """
+    creds = None
+    
+    # Check if token file exists
+    if os.path.exists(TOKEN_FILE):
+        creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
+    
+    # If credentials don't exist or are invalid, get new ones
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            # Check if client secrets file exists
+            if not os.path.exists(OAUTH_CLIENT_SECRETS_FILE):
+                raise FileNotFoundError(
+                    f"OAuth client secrets file not found. Please place a client_secrets.json file in the script directory "
+                    f"or set the GSC_OAUTH_CLIENT_SECRETS_FILE environment variable."
+                )
+            
+            # Start OAuth flow
+            flow = InstalledAppFlow.from_client_secrets_file(OAUTH_CLIENT_SECRETS_FILE, SCOPES)
+            creds = flow.run_local_server(port=0)
+            
+            # Save the credentials for future use
+            with open(TOKEN_FILE, 'w') as token:
+                token.write(creds.to_json())
+    
+    # Build and return the service
+    return build("searchconsole", "v1", credentials=creds)
 
 @mcp.tool()
 async def list_properties() -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 google-api-python-client>=2.0.0
 oauth2client>=4.1.3
 google-auth>=2.0.0
+google-auth-oauthlib>=1.2.1


### PR DESCRIPTION
This pull request implements the OAuth flow, allowing users to use their own authorized GSC accounts instead of having to use service accounts.
Retains the service account option as fallback, with a possibility to skip OAuth completely by setting `GSC_SKIP_OAUTH`.