### PR TITLE
feat: Add missing add_site and delete_site tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A tool that connects [Google Search Console](https://search.google.com/search-co
 1. **Property Management**  
    - See all your GSC properties in one place
    - Get verification details and basic site information
+   - Add new properties to your account
+   - Remove properties from your account
 
 2. **Search Analytics & Reporting**  
    - Discover which search queries bring visitors to your site
@@ -39,6 +41,8 @@ Here's what you can ask Claude to do once you've set up this integration:
 |---------------------------------|-------------------------------------------------------------|----------------------------------------------------------------|
 | `list_properties`               | Shows all your GSC properties                               | Nothing - just ask!                                             |
 | `get_site_details`              | Shows details about a specific site                         | Your website URL                                                |
+| `add_site`                      | Adds a new site to your GSC properties                      | Your website URL                                                |
+| `delete_site`                   | Removes a site from your GSC properties                     | Your website URL                                                |
 | `get_search_analytics`          | Shows top queries and pages with metrics                    | Your website URL and time period                                |
 | `get_performance_overview`      | Gives a summary of site performance                         | Your website URL and time period                                |
 | `check_indexing_issues`         | Checks if pages have indexing problems                      | Your website URL and list of pages to check                     |
@@ -46,7 +50,7 @@ Here's what you can ask Claude to do once you've set up this integration:
 | `get_sitemaps`                  | Lists all sitemaps for your site                            | Your website URL                                                |
 | `submit_sitemap`                | Submits a new sitemap to Google                             | Your website URL and sitemap URL                                |
 
-*For a complete list of all 17 available tools and their detailed descriptions, ask Claude to "list tools" after setup.*
+*For a complete list of all 19 available tools and their detailed descriptions, ask Claude to "list tools" after setup.*
 
 ---
 
@@ -218,6 +222,8 @@ Here are some powerful prompts you can use with each tool:
 |---------------------------------|--------------------------------------------------------------------------------------------------|
 | `list_properties`               | "List all my GSC properties and tell me which ones have the most pages indexed."                 |
 | `get_site_details`              | "Analyze the verification status of mywebsite.com and explain what the ownership details mean."  |
+| `add_site`                      | "Add my new website https://mywebsite.com to Search Console and verify its status."              |
+| `delete_site`                   | "Remove the old test site https://test.mywebsite.com from Search Console."                       |
 | `get_search_analytics`          | "Show me the top 20 search queries for mywebsite.com in the last 30 days, highlight any with CTR below 2%, and suggest title improvements." |
 | `get_performance_overview`      | "Create a visual performance overview of mywebsite.com for the last 28 days, identify any unusual drops or spikes, and explain possible causes." |
 | `check_indexing_issues`         | "Check these important pages for indexing issues and prioritize which ones need immediate attention: mywebsite.com/product, mywebsite.com/services, mywebsite.com/about" |

--- a/gsc_server.py
+++ b/gsc_server.py
@@ -26,7 +26,7 @@ POSSIBLE_CREDENTIAL_PATHS = [
     # Add any other potential paths here
 ]
 
-SCOPES = ["https://www.googleapis.com/auth/webmasters.readonly"]
+SCOPES = ["https://www.googleapis.com/auth/webmasters"]
 
 def get_gsc_service():
     """
@@ -90,6 +90,111 @@ async def list_properties() -> str:
         )
     except Exception as e:
         return f"Error retrieving properties: {str(e)}"
+
+@mcp.tool()
+async def add_site(site_url: str) -> str:
+    """
+    Add a site to your Search Console properties.
+    
+    Args:
+        site_url: The URL of the site to add (must be exact match e.g. https://example.com, or https://www.example.com, or https://subdomain.example.com/path/, for domain properties use format: sc-domain:example.com)
+    """
+    try:
+        service = get_gsc_service()
+        
+        # Add the site
+        response = service.sites().add(siteUrl=site_url).execute()
+        
+        # Format the response
+        result_lines = [f"Site {site_url} has been added to Search Console."]
+        
+        # Add permission level if available
+        if "permissionLevel" in response:
+            result_lines.append(f"Permission level: {response['permissionLevel']}")
+        
+        return "\n".join(result_lines)
+    except HttpError as e:
+        error_content = json.loads(e.content.decode('utf-8'))
+        error_details = error_content.get('error', {})
+        error_code = e.resp.status
+        error_message = error_details.get('message', str(e))
+        error_reason = error_details.get('errors', [{}])[0].get('reason', '')
+        
+        if error_code == 409:
+            return f"Site {site_url} is already added to Search Console."
+        elif error_code == 403:
+            if error_reason == 'forbidden':
+                return f"Error: You don't have permission to add this site. Please verify ownership first."
+            elif error_reason == 'quotaExceeded':
+                return f"Error: API quota exceeded. Please try again later."
+            else:
+                return f"Error: Permission denied. {error_message}"
+        elif error_code == 400:
+            if error_reason == 'invalidParameter':
+                return f"Error: Invalid site URL format. Please check the URL format and try again."
+            else:
+                return f"Error: Bad request. {error_message}"
+        elif error_code == 401:
+            return f"Error: Unauthorized. Please check your credentials."
+        elif error_code == 429:
+            return f"Error: Too many requests. Please try again later."
+        elif error_code == 500:
+            return f"Error: Internal server error from Google Search Console API. Please try again later."
+        elif error_code == 503:
+            return f"Error: Service unavailable. Google Search Console API is currently down. Please try again later."
+        else:
+            return f"Error adding site (HTTP {error_code}): {error_message}"
+    except Exception as e:
+        return f"Error adding site: {str(e)}"
+
+@mcp.tool()
+async def delete_site(site_url: str) -> str:
+    """
+    Remove a site from your Search Console properties.
+    
+    Args:
+        site_url: The URL of the site to remove (must be exact match e.g. https://example.com, or https://www.example.com, or https://subdomain.example.com/path/, for domain properties use format: sc-domain:example.com)
+    """
+    try:
+        service = get_gsc_service()
+        
+        # Delete the site
+        service.sites().delete(siteUrl=site_url).execute()
+        
+        return f"Site {site_url} has been removed from Search Console."
+    except HttpError as e:
+        error_content = json.loads(e.content.decode('utf-8'))
+        error_details = error_content.get('error', {})
+        error_code = e.resp.status
+        error_message = error_details.get('message', str(e))
+        error_reason = error_details.get('errors', [{}])[0].get('reason', '')
+        
+        if error_code == 404:
+            return f"Site {site_url} was not found in Search Console."
+        elif error_code == 403:
+            if error_reason == 'forbidden':
+                return f"Error: You don't have permission to remove this site."
+            elif error_reason == 'quotaExceeded':
+                return f"Error: API quota exceeded. Please try again later."
+            else:
+                return f"Error: Permission denied. {error_message}"
+        elif error_code == 400:
+            if error_reason == 'invalidParameter':
+                return f"Error: Invalid site URL format. Please check the URL format and try again."
+            else:
+                return f"Error: Bad request. {error_message}"
+        elif error_code == 401:
+            return f"Error: Unauthorized. Please check your credentials."
+        elif error_code == 429:
+            return f"Error: Too many requests. Please try again later."
+        elif error_code == 500:
+            return f"Error: Internal server error from Google Search Console API. Please try again later."
+        elif error_code == 503:
+            return f"Error: Service unavailable. Google Search Console API is currently down. Please try again later."
+        else:
+            return f"Error removing site (HTTP {error_code}): {error_message}"
+    except Exception as e:
+        return f"Error removing site: {str(e)}"
 
 @mcp.tool()
 async def get_search_analytics(site_url: str, days: int = 28, dimensions: str = "query") -> str:


### PR DESCRIPTION
This PR implements missing Sites _add_ and _delete_ API methods while changing the scope to read/write to facilitate that.

Allows adding and removing many properties in GSC without having to do it manually in the GUI.