### PR TITLE
Fix TypeError in get_sitemaps and list_sitemaps_enhanced

### DIFF
--- a/gsc_server.py
+++ b/gsc_server.py
@@ -422,13 +422,13 @@ async def get_sitemaps(site_url: str) -> str:
                     pass
             
             status = "Valid"
-            if "errors" in sitemap and sitemap["errors"] > 0:
+            if "errors" in sitemap and int(sitemap["errors"]) > 0:
                 status = "Has errors"
             
             # Get counts
-            warnings = sitemap.get("warnings", 0)
-            errors = sitemap.get("errors", 0)
-            
+            warnings = int(sitemap.get("warnings", 0))
+            errors = int(sitemap.get("errors", 0))
+
             # Get contents if available
             indexed_urls = "N/A"
             if "contents" in sitemap:
@@ -1227,9 +1227,9 @@ async def list_sitemaps_enhanced(site_url: str, sitemap_index: str = None) -> st
             sitemap_type = "Index" if sitemap.get("isSitemapsIndex", False) else "Sitemap"
             
             # Get counts
-            errors = sitemap.get("errors", 0)
-            warnings = sitemap.get("warnings", 0)
-            
+            errors = int(sitemap.get("errors", 0))
+            warnings = int(sitemap.get("warnings", 0))
+
             # Get URL counts
             url_count = "N/A"
             if "contents" in sitemap:


### PR DESCRIPTION
## Summary

- The Google Search Console API returns `errors` and `warnings` counts as **strings** (e.g. `"0"`), but the code compared them directly to integers, causing `TypeError: '>' not supported between instances of 'str' and 'int'`
- Added `int()` casts in `get_sitemaps` and `list_sitemaps_enhanced` before comparison and assignment

## Test plan

- [ ] Call `get_sitemaps` tool with a site that has sitemaps — should return results without TypeError
- [ ] Call `list_sitemaps_enhanced` tool — should return results without TypeError
- [ ] Verify sitemaps with non-zero errors/warnings display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)