### PR TITLE
fix: prevent OAuth from blocking forever in MCP stdio mode

### DIFF
--- a/gsc_server.py
+++ b/gsc_server.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Optional
 import logging
 import os
 import json
+import sys
 from datetime import datetime, timedelta
 
 import google.auth
@@ -124,14 +125,25 @@ def get_gsc_service_oauth():
         
         # Start new OAuth flow if we don't have valid credentials
         if not creds or not creds.valid:
+            # IMPORTANT: When running as MCP server (stdio), run_local_server() blocks
+            # forever because no browser can open. Only allow interactive OAuth when
+            # running directly from terminal (stdin is a TTY).
+            if not sys.stdin.isatty():
+                raise RuntimeError(
+                    "OAuth token is missing or expired and cannot be refreshed. "
+                    "Run the OAuth flow manually first:\n"
+                    f"  cd {SCRIPT_DIR} && python gsc_server.py\n"
+                    "Then restart Claude Code."
+                )
+
             # Check if client secrets file exists
             if not os.path.exists(OAUTH_CLIENT_SECRETS_FILE):
                 raise FileNotFoundError(
                     f"OAuth client secrets file not found. Please place a client_secrets.json file in the script directory "
                     f"or set the GSC_OAUTH_CLIENT_SECRETS_FILE environment variable."
                 )
-            
-            # Start OAuth flow
+
+            # Start OAuth flow (only when running interactively)
             flow = InstalledAppFlow.from_client_secrets_file(OAUTH_CLIENT_SECRETS_FILE, SCOPES)
             creds = flow.run_local_server(port=0)
             
@@ -1624,6 +1636,16 @@ async def reauthenticate() -> str:
                 "Cannot start new authentication flow. "
                 "Please ensure client_secrets.json is present or set the "
                 "GSC_OAUTH_CLIENT_SECRETS_FILE environment variable."
+            )
+
+        # IMPORTANT: run_local_server() blocks forever when running as MCP subprocess.
+        if not sys.stdin.isatty():
+            msg = "Token deleted. " if token_deleted else ""
+            return (
+                msg + "Cannot open browser for re-authentication from MCP. "
+                "Run manually:\n"
+                f"  cd {SCRIPT_DIR} && .venv/bin/python gsc_server.py\n"
+                "Then restart Claude Code."
             )
 
         # Trigger new OAuth flow — this opens a browser window on the local machine


### PR DESCRIPTION
## Problem

When `mcp-gsc` runs as an MCP subprocess (e.g. via Claude Code), stdin is a pipe — not a TTY. The existing OAuth flow calls `run_local_server()` which tries to open a browser and listen for a callback. In a non-interactive subprocess this blocks forever with no error, silently hanging the MCP server.

## Fix

Added a `sys.stdin.isatty()` check in two places:

1. **`get_service()`** — before starting the OAuth browser flow, raises a `RuntimeError` with instructions to run OAuth manually from a terminal
2. **`reauthenticate()` tool** — same guard, returns a helpful message instead of blocking

No changes to behavior when running interactively (TTY) — the browser OAuth flow works exactly as before.

## Testing

Verified with Claude Code's MCP integration against a live Google Search Console property (`sc-domain:hskstory.com`). All 20 tools work correctly. When the token expires, the error message correctly instructs the user to re-authenticate manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)