### PR TITLE
feat: add uvx/pipx support via console_scripts entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,45 @@ The configuration below uses Claude Desktop as an example. For other clients (Cu
    }
    ```
 
+#### uvx / pipx (no clone needed)
+
+   If you have [uv](https://docs.astral.sh/uv/) or pipx installed, you can run the server directly without cloning the repo:
+
+   ```json
+   {
+     "mcpServers": {
+       "gscServer": {
+         "command": "uvx",
+         "args": ["mcp-gsc"],
+         "env": {
+           "GSC_CREDENTIALS_PATH": "/FULL/PATH/TO/service_account_credentials.json",
+           "GSC_SKIP_OAUTH": "true",
+           "GSC_DATA_STATE": "all"
+         }
+       }
+     }
+   }
+   ```
+
+   For OAuth authentication with uvx:
+
+   ```json
+   {
+     "mcpServers": {
+       "gscServer": {
+         "command": "uvx",
+         "args": ["mcp-gsc"],
+         "env": {
+           "GSC_OAUTH_CLIENT_SECRETS_FILE": "/FULL/PATH/TO/client_secrets.json",
+           "GSC_DATA_STATE": "all"
+         }
+       }
+     }
+   }
+   ```
+
+   uvx automatically downloads and runs the latest published version of `mcp-gsc` from PyPI in an isolated environment. No manual install, venv creation, or path configuration needed.
+
 #### Environment Variables Reference
 
 | Variable | Required | Default | Description |

--- a/gsc_server.py
+++ b/gsc_server.py
@@ -1643,6 +1643,10 @@ async def reauthenticate() -> str:
         return f"Error during reauthentication: {str(e)}"
 
 
-if __name__ == "__main__":
-    # Start the MCP server on stdio transport
+def main():
+    """Entry point for uvx / pipx / pip install execution."""
     mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dependencies = [
 "Homepage" = "https://github.com/aminfseo/mcp-gsc"
 "Bug Tracker" = "https://github.com/aminfseo/mcp-gsc/issues"
 
+
+[project.scripts]
+mcp-gsc = "gsc_server:main"
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Closes #9

Adds uvx/pipx support so users can run the server without cloning the repo or managing a virtual environment manually.

**Changes:**

1. **`gsc_server.py`**: wraps `mcp.run()` in a `main()` function so it can be called as a console script entry point
2. **`pyproject.toml`**: adds `[project.scripts]` entry pointing to `gsc_server:main`
3. **`README.md`**: adds a `uvx / pipx (no clone needed)` config section showing both service account and OAuth examples

**How it works after this PR:**

```json
{
  "mcpServers": {
    "gscServer": {
      "command": "uvx",
      "args": ["mcp-gsc"],
      "env": {
        "GSC_CREDENTIALS_PATH": "/path/to/service_account_credentials.json",
        "GSC_SKIP_OAUTH": "true"
      }
    }
  }
}
```

uvx downloads the latest `mcp-gsc` from PyPI and runs it in an isolated environment. No clone, no venv, no path setup required. This is especially convenient for users who are just trying out the tool or want a zero-maintenance setup.