### PR TITLE
Multi-tenant GSC_AUTH_MODE=bearer + fix SSE transport (closes #33)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY pyproject.toml README.md ./
 RUN uv sync --no-cache --no-install-project
 
 # Copy application code
-COPY gsc_server.py .
+COPY gsc_server.py bearer_context.py ./
 
 # Default to stdio transport; override with MCP_TRANSPORT=sse for remote/network use
 CMD ["uv", "run", "--no-sync", "python", "gsc_server.py"]

--- a/bearer_context.py
+++ b/bearer_context.py
@@ -1,0 +1,53 @@
+"""Per-request bearer-token capture for multi-tenant `GSC_AUTH_MODE=bearer`.
+
+When the env var ``GSC_AUTH_MODE=bearer`` is set, the SSE/streamable-http
+transport installs :class:`BearerCaptureMiddleware`, which extracts the
+``Authorization: Bearer <token>`` header from each incoming request into a
+:class:`contextvars.ContextVar`.  ``get_gsc_service()`` then builds Google API
+credentials from that per-request token, so the server calls Search Console
+as the *user who made the MCP request* rather than as a single shared
+identity.
+
+This matches the pattern used by Google's hosted MCPs (drivemcp.googleapis.com
+etc.) and lets MCP clients such as LibreChat run the OAuth flow per user and
+simply forward the user's access token to the MCP server — no service-account
+or on-disk refresh token required on the server side.
+
+Single-tenant modes (OAuth-on-disk, service account) are unchanged and remain
+the default when ``GSC_AUTH_MODE`` is unset.
+"""
+
+from contextvars import ContextVar
+from typing import Optional
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+current_bearer: ContextVar[Optional[str]] = ContextVar(
+    "current_bearer", default=None
+)
+
+
+def _extract_bearer(header_value: str) -> Optional[str]:
+    """Return the token from a ``Bearer <token>`` header, or None."""
+    if not header_value or not header_value.lower().startswith("bearer "):
+        return None
+    token = header_value[7:].strip()
+    return token or None
+
+
+class BearerCaptureMiddleware(BaseHTTPMiddleware):
+    """Captures ``Authorization: Bearer <token>`` into :data:`current_bearer`.
+
+    The token is scoped to the request via :mod:`contextvars`, so per-request
+    isolation is preserved across concurrent async handlers.
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        token = _extract_bearer(request.headers.get("authorization", ""))
+        reset_token = current_bearer.set(token)
+        try:
+            return await call_next(request)
+        finally:
+            current_bearer.reset(reset_token)

--- a/bearer_context.py
+++ b/bearer_context.py
@@ -1,9 +1,9 @@
-"""Per-request bearer-token capture for multi-tenant `GSC_AUTH_MODE=bearer`.
+"""Per-request bearer-token capture for multi-tenant ``GSC_AUTH_MODE=bearer``.
 
 When the env var ``GSC_AUTH_MODE=bearer`` is set, the SSE/streamable-http
 transport installs :class:`BearerCaptureMiddleware`, which extracts the
 ``Authorization: Bearer <token>`` header from each incoming request into a
-:class:`contextvars.ContextVar`.  ``get_gsc_service()`` then builds Google API
+:class:`contextvars.ContextVar`. ``get_gsc_service()`` then builds Google API
 credentials from that per-request token, so the server calls Search Console
 as the *user who made the MCP request* rather than as a single shared
 identity.
@@ -15,14 +15,17 @@ or on-disk refresh token required on the server side.
 
 Single-tenant modes (OAuth-on-disk, service account) are unchanged and remain
 the default when ``GSC_AUTH_MODE`` is unset.
+
+NOTE: This is implemented as a **pure ASGI middleware** rather than subclassing
+Starlette's :class:`BaseHTTPMiddleware`. ``BaseHTTPMiddleware`` buffers the
+response body, which breaks **streaming SSE responses** with an
+``AssertionError: Unexpected message`` from ``body_stream`` — exactly what
+FastMCP's SSE endpoint serves. The pure ASGI form does not touch the response
+stream at all.
 """
 
 from contextvars import ContextVar
 from typing import Optional
-
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.requests import Request
-from starlette.responses import Response
 
 current_bearer: ContextVar[Optional[str]] = ContextVar(
     "current_bearer", default=None
@@ -37,17 +40,30 @@ def _extract_bearer(header_value: str) -> Optional[str]:
     return token or None
 
 
-class BearerCaptureMiddleware(BaseHTTPMiddleware):
-    """Captures ``Authorization: Bearer <token>`` into :data:`current_bearer`.
+class BearerCaptureMiddleware:
+    """Pure ASGI middleware that captures ``Authorization: Bearer <token>``
+    into :data:`current_bearer` for the duration of each HTTP request.
 
-    The token is scoped to the request via :mod:`contextvars`, so per-request
-    isolation is preserved across concurrent async handlers.
+    Implemented as a pure ASGI middleware (not ``BaseHTTPMiddleware``) so it
+    is safe in front of streaming responses such as the FastMCP SSE endpoint.
     """
 
-    async def dispatch(self, request: Request, call_next) -> Response:
-        token = _extract_bearer(request.headers.get("authorization", ""))
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") != "http":
+            # WebSocket / lifespan: pass through unchanged.
+            await self.app(scope, receive, send)
+            return
+
+        # ASGI headers are list[(bytes, bytes)]; convert lowercase keys to dict.
+        headers = {k.decode("latin-1").lower(): v for k, v in scope.get("headers", [])}
+        auth_header = headers.get("authorization", b"").decode("latin-1")
+        token = _extract_bearer(auth_header)
+
         reset_token = current_bearer.set(token)
         try:
-            return await call_next(request)
+            await self.app(scope, receive, send)
         finally:
             current_bearer.reset(reset_token)

--- a/gsc_server.py
+++ b/gsc_server.py
@@ -93,8 +93,41 @@ SCOPES = ["https://www.googleapis.com/auth/webmasters"]
 def get_gsc_service():
     """
     Returns an authorized Search Console service object.
-    First tries OAuth authentication, then falls back to service account.
+
+    Authentication mode is selected by the ``GSC_AUTH_MODE`` env var:
+
+    * ``bearer`` — multi-tenant. Builds credentials from the per-request
+      ``Authorization: Bearer <access_token>`` header captured by
+      :class:`bearer_context.BearerCaptureMiddleware` (registered in SSE mode).
+      The MCP server holds no credentials of its own; each request calls
+      Google as the user that originated it. Matches Google's hosted MCP
+      pattern (drivemcp.googleapis.com etc.) — suitable when an upstream MCP
+      client (LibreChat, etc.) already performs OAuth per user and forwards
+      the access token.
+    * unset / anything else — single-tenant. First tries OAuth authentication,
+      then falls back to service account (the original behaviour).
     """
+    # Bearer (multi-tenant) mode: per-request Google access token from the
+    # Authorization header — no on-disk credentials needed.
+    if os.environ.get("GSC_AUTH_MODE", "").lower() == "bearer":
+        from bearer_context import current_bearer
+        from google.oauth2.credentials import Credentials as OAuthCredentials
+
+        token = current_bearer.get()
+        if not token:
+            # Mirrors a 401 to the MCP client so it can trigger its OAuth flow
+            # (e.g. LibreChat with `requiresOAuth: true`).
+            raise PermissionError(
+                "GSC_AUTH_MODE=bearer but no Authorization: Bearer <token> on "
+                "the incoming MCP request. Either the MCP client did not "
+                "forward an OAuth access token, or it sent the request before "
+                "completing the OAuth flow."
+            )
+        creds = OAuthCredentials(token=token)
+        return build(
+            "searchconsole", "v1", credentials=creds, cache_discovery=False
+        )
+
     # Fail-fast if credential env vars are set but point to files that don't exist.
     # Without this, a typo'd or uvx-incompatible path would silently fall through to
     # SCRIPT_DIR/cwd fallbacks (which don't work under uvx) and emit a misleading
@@ -1668,7 +1701,33 @@ def main():
     if transport == "stdio":
         mcp.run(transport="stdio")
     elif transport in {"sse", "http"}:
-        mcp.run(transport="sse", host=host, port=port)
+        # FastMCP.run() no longer accepts host/port kwargs in newer mcp SDK;
+        # set them on settings before calling run.
+        mcp.settings.host = host
+        mcp.settings.port = port
+        # mcp SDK >=1.27 enables DNS-rebinding protection with a Host allowlist
+        # of 127.0.0.1/localhost only. SSE is documented for remote/Docker use
+        # (MCP_HOST=0.0.0.0), where Host headers like gsc-mcp:3001 fail the
+        # allowlist and return HTTP 421 Misdirected Request — the operator has
+        # already opted into remote binding via MCP_HOST, so disable the check.
+        try:
+            mcp.settings.transport_security.enable_dns_rebinding_protection = False
+        except Exception:
+            pass
+
+        # Multi-tenant bearer mode: install a Starlette middleware on the SSE
+        # app that captures each request's Authorization: Bearer <token> into
+        # a ContextVar, then run uvicorn directly. See bearer_context.py and
+        # get_gsc_service().
+        if os.environ.get("GSC_AUTH_MODE", "").lower() == "bearer":
+            import uvicorn
+            from bearer_context import BearerCaptureMiddleware
+
+            app = mcp.sse_app()
+            app.add_middleware(BearerCaptureMiddleware)
+            uvicorn.run(app, host=host, port=port)
+        else:
+            mcp.run(transport="sse")
     else:
         raise ValueError(
             f"Unknown MCP_TRANSPORT '{transport}'. "


### PR DESCRIPTION
### Summary

Bundles the two SSE breakage fixes (from #33) with a new opt-in **`GSC_AUTH_MODE=bearer`** that makes the server multi-tenant — taking the OAuth access token from each incoming MCP request's `Authorization: Bearer …` header and calling Search Console as that user. Matches the pattern of Google's hosted MCPs (e.g. `drivemcp.googleapis.com`) and lets clients like LibreChat run the OAuth flow per user and forward the token, instead of the server holding a single shared credential.

Three changes:

#### 1. SSE fix — `FastMCP.run()` no longer accepts `host` / `port`
The mcp SDK removed those kwargs; they must be set on `mcp.settings` first.
```diff
-        mcp.run(transport="sse", host=host, port=port)
+        mcp.settings.host = host
+        mcp.settings.port = port
+        mcp.run(transport="sse")
```

#### 2. SSE fix — disable DNS-rebinding protection on the documented remote-binding path
mcp SDK ≥ 1.27 ships `TransportSecuritySettings` with `enable_dns_rebinding_protection = True` and `allowed_hosts = ['127.0.0.1:*', 'localhost:*', '[::1]:*']` — so every SSE request whose `Host` header isn't localhost returns **HTTP 421 Misdirected Request**. That breaks the documented `MCP_HOST=0.0.0.0 MCP_PORT=3001` / Docker setup. The operator has already opted into remote binding via `MCP_HOST`, so disable the check:
```python
try:
    mcp.settings.transport_security.enable_dns_rebinding_protection = False
except Exception:
    pass
```
Together with (1), this makes the README's `docker run -e MCP_TRANSPORT=sse -e MCP_PORT=3001 -p 3001:3001 …` example work as advertised.

A more conservative alternative would be a new `MCP_ALLOWED_HOSTS` env that extends the allowlist instead of disabling the check. Happy to switch to that if you prefer — flag it in review.

#### 3. Feature — `GSC_AUTH_MODE=bearer` (multi-tenant)
- New `bearer_context.py`: `ContextVar` + small Starlette middleware that captures `Authorization: Bearer <token>` per request.
- `get_gsc_service()` gains a branch that — when `GSC_AUTH_MODE=bearer` — builds `google.oauth2.credentials.Credentials(token=…)` from the per-request `ContextVar` and calls Search Console as that user. Raises `PermissionError` if no bearer is present, so the upstream MCP client (e.g. LibreChat with `requiresOAuth: true`) sees an auth error and can trigger its OAuth flow.
- SSE branch in `main()` installs the middleware on `mcp.sse_app()` and runs `uvicorn` directly when bearer mode is on.

**Single-tenant modes (OAuth-on-disk, service account) are unchanged and remain the default** when `GSC_AUTH_MODE` is unset. Bearer mode is purely additive and opt-in.

#### Why this matters for users
Google currently has a confirmed bug ([piunikaweb 2026-05-01](https://piunikaweb.com/2026/05/01/google-service-account-email-not-found-bug/), [Google Search Central thread](https://support.google.com/webmasters/community-guide/429538961/)) where service accounts created from ~April 23, 2026 onwards can't be added to Search Console at all — *"Failed to add user: email not found"* / *"unspecified error"*. There's no workaround in the GSC UI and **no equivalent of the Analytics Admin API** for permissions, so the SA route is dead for any new deployment until Google ships a fix. Bearer mode sidesteps the bug entirely because each LibreChat user authenticates with their *own* Google account (which already has GSC access), so no service account is needed on the server side.

### Verification
- Built against `mcp==1.27.1` in your shipped Dockerfile.
- LibreChat (`registry.librechat.ai/danny-avila/librechat-dev` ≥ 2026-05-23) connects via `type: sse` + `requiresOAuth: true` and registers all 21 tools, with `OAuth Required: true` reported in the MCP server card.
- Existing stdio + SA flows verified unchanged.

### Files changed
- `gsc_server.py` — `get_gsc_service()` bearer branch; `main()` SSE path adjustments
- `bearer_context.py` — new (≈40 lines)
- `Dockerfile` — copy `bearer_context.py` alongside `gsc_server.py`

### Compat
- No new runtime deps. `starlette` is already pulled in transitively by `mcp[sse]`.
- All existing behaviour is the default; bearer mode is reachable only via the new env var.

Happy to split this into two PRs (SSE fixes vs feature) if you prefer that history. They're bundled here because the bearer feature is unreachable without the SSE fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
