### PR TITLE
Bump mcp[cli] floor to >=1.27.2 to clear known CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "google-api-python-client>=2.163.0",
     "google-auth-httplib2>=0.2.0",
     "google-auth-oauthlib>=1.2.1",
-    "mcp[cli]>=1.3.0",
+    "mcp[cli]>=1.27.2",
     "platformdirs>=4.0.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 google-api-python-client>=2.163.0
 google-auth-httplib2>=0.2.0
 google-auth-oauthlib>=1.2.1
-mcp[cli]>=1.3.0
+mcp[cli]>=1.27.2
 platformdirs>=4.0.0


### PR DESCRIPTION
## What

Raises the `mcp[cli]` dependency floor from `>=1.3.0` to `>=1.27.2` in both `requirements.txt` and `pyproject.toml`.

## Why

The current lower bound `>=1.3.0` permits versions of the MCP Python SDK affected by four published advisories. A fresh install pulls the latest SDK, but any environment resolving/locking to the floor (reproducible builds, existing lockfiles, cached resolutions) can still land on a vulnerable version.

| Advisory | Issue | First patched |
|----------|-------|---------------|
| [GHSA-3qhf-m339-9g5v](https://github.com/advisories/GHSA-3qhf-m339-9g5v) | DoS — FastMCP server validation error | 1.9.4 |
| [GHSA-j975-95f5-7wqh](https://github.com/advisories/GHSA-j975-95f5-7wqh) | DoS — unhandled exception in Streamable HTTP transport | 1.10.0 |
| [GHSA-9h52-p55h-vw2f](https://github.com/advisories/GHSA-9h52-p55h-vw2f) | DNS rebinding protection not enabled by default | 1.23.0 |
| [GHSA-jpw9-pfvf-9f58](https://github.com/advisories/GHSA-jpw9-pfvf-9f58) | HTTP transports serve session requests without verifying the authenticated principal | 1.27.2 |

`>=1.27.2` is the minimum floor that clears all four (latest published is 1.28.1).

## Notes

Most of these only apply when the server is exposed over HTTP/Streamable transport rather than local stdio, so real-world impact for typical desktop-client usage is limited — but raising the floor is a zero-cost hardening step and matters for any HTTP deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
