### PR TITLE
fix(skills): indexing-audit sorts by clicks, not impressions

### DIFF
--- a/skills/indexing-audit/SKILL.md
+++ b/skills/indexing-audit/SKILL.md
@@ -11,7 +11,7 @@ Audit the indexing status of the top pages on a site and produce a prioritized a
 ## Steps
 
 1. Call `list_properties` to confirm the exact `site_url`.
-2. Call `get_search_analytics` with `dimensions=page`, `sort_by=impressions`, `row_limit=20` to identify the 20 most-visible pages.
+2. Call `get_advanced_search_analytics` with `dimensions=page`, `sort_by=impressions`, `row_limit=20` to identify the 20 most-visible pages.
 3. Extract the list of page URLs from the results.
 4. Call `batch_url_inspection` with up to 10 URLs at a time (API limit). Run twice if needed to cover all 20 pages.
 5. Categorize each URL by verdict:


### PR DESCRIPTION
`skills/indexing-audit/SKILL.md` step 2 calls `get_search_analytics` with `sort_by=impressions`, but that tool's signature is `site_url`, `days`, `dimensions`, `row_limit` (`gsc_server.py:463`). There is no `sort_by`, so the argument does nothing and the skill audits the top 20 pages **by clicks** — GSC's default ordering — while telling the model they are the 20 most-visible pages.

That matters here more than it might elsewhere: a page with high impressions and no clicks is precisely the sort of result an indexing audit wants to look at, and it is precisely the sort this ordering drops.

`get_advanced_search_analytics` accepts `sort_by` and defaults to the same 28-day window, so it is a drop-in. `cannibalization-check` and `content-opportunities` already use that tool where they sort.

One line, no behaviour change beyond the intended ordering.

Found while checking the four skills against a deployment of this server. Thanks for the project — the skills are a nice touch.