### PR TITLE
fix: read rich-result issues from the key the API actually returns

### DIFF
--- a/gsc_server.py
+++ b/gsc_server.py
@@ -677,9 +677,20 @@ async def inspect_url_enhanced(site_url: str, page_url: str) -> str:
                     item.get("richResultType", "Unknown")
                     for item in rich.get("detectedItems", [])
                 ],
+                # Issues are nested under detectedItems[].items[].issues[] and the
+                # message key is "issueMessage". Reading a top-level
+                # "richResultsIssues" key -- which the API never returns -- made this
+                # list always empty, hiding every rich-result problem.
                 "issues": [
-                    {"severity": issue.get("severity"), "message": issue.get("message")}
-                    for issue in rich.get("richResultsIssues", [])
+                    {
+                        "type": detected.get("richResultType", "Unknown"),
+                        "item": item.get("name"),
+                        "severity": issue.get("severity"),
+                        "message": issue.get("issueMessage"),
+                    }
+                    for detected in rich.get("detectedItems", [])
+                    for item in detected.get("items", [])
+                    for issue in item.get("issues", [])
                 ],
             }
 

--- a/test_gsc_server.py
+++ b/test_gsc_server.py
@@ -422,6 +422,42 @@ class TestInspectUrl(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(data["page_url"], "https://example.com/page/")
         self.assertIn("last_crawled", data)
 
+    async def test_reports_rich_result_issues(self):
+        mod = _load_module()
+        service = _make_service()
+        service.urlInspection().index().inspect().execute.return_value = {
+            "inspectionResult": {
+                "indexStatusResult": {"verdict": "PASS"},
+                "richResultsResult": {
+                    "verdict": "PASS",
+                    "detectedItems": [
+                        {
+                            "richResultType": "Merchant listings",
+                            "items": [
+                                {
+                                    "name": "Example product",
+                                    "issues": [
+                                        {
+                                            "issueMessage": "Missing field 'shippingDetails'",
+                                            "severity": "WARNING",
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                },
+            }
+        }
+        with patch("gsc_server.get_gsc_service", return_value=service):
+            result = await mod.inspect_url_enhanced("https://example.com/", "https://example.com/page/")
+        issues = json.loads(result)["rich_results"]["issues"]
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0]["severity"], "WARNING")
+        self.assertEqual(issues[0]["message"], "Missing field 'shippingDetails'")
+        self.assertEqual(issues[0]["type"], "Merchant listings")
+        self.assertEqual(issues[0]["item"], "Example product")
+
 
 # ---------------------------------------------------------------------------
 # TestBatchUrlInspection


### PR DESCRIPTION
Fixes #46.

`inspect_url_enhanced` built `rich_results.issues` from a top-level `richResultsIssues` key that the URL Inspection API never returns, so the list was always empty and every rich-result problem was silently dropped. WARNING-severity issues leave `verdict` at `PASS`, so nothing else in the response hinted that anything had been found — the tool reported a clean page while Search Console was emailing about it.

Per the [API reference](https://developers.google.com/webmaster-tools/v1/urlInspection.index/inspect), issues live one level deeper and use `issueMessage`:

```
richResultsResult
  detectedItems[]
    richResultType
    items[]
      name
      issues[]
        issueMessage
        severity
```

This walks that structure. Each entry now also carries `type` (the `richResultType`) and `item` (the item `name`), because a single URL can detect several rich-result types and an issue is otherwise hard to attribute to one of them.

The added test fails on `main` with `AssertionError: 0 != 1` and passes with the fix.

```
44 passed in 0.76s
```