### PR TITLE
fix: report rich results failures in batch_url_inspection

### DIFF
--- a/gsc_server.py
+++ b/gsc_server.py
@@ -631,6 +631,39 @@ async def get_sitemaps(site_url: str) -> str:
             return _site_not_found_error(site_url)
         return f"Error retrieving sitemaps: {str(e)}"
 
+def _rich_results_summary(inspection: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Shape the richResultsResult of a URL inspection into a reportable summary.
+
+    Shared by inspect_url_enhanced and batch_url_inspection so both tools report the
+    same thing for the same page.
+
+    Issues are nested under detectedItems[].items[].issues[] and the message key is
+    "issueMessage". Reading a top-level "richResultsIssues" key -- which the API never
+    returns -- made this list always empty, hiding every rich-result problem.
+    """
+    if "richResultsResult" not in inspection:
+        return None
+
+    rich = inspection["richResultsResult"]
+    return {
+        "verdict": rich.get("verdict", "UNKNOWN"),
+        "detected_types": [
+            item.get("richResultType", "Unknown")
+            for item in rich.get("detectedItems", [])
+        ],
+        "issues": [
+            {
+                "type": detected.get("richResultType", "Unknown"),
+                "item": item.get("name"),
+                "severity": issue.get("severity"),
+                "message": issue.get("issueMessage"),
+            }
+            for detected in rich.get("detectedItems", [])
+            for item in detected.get("items", [])
+            for issue in item.get("issues", [])
+        ],
+    }
+
 @mcp.tool()
 async def inspect_url_enhanced(site_url: str, page_url: str) -> str:
     """
@@ -668,31 +701,7 @@ async def inspect_url_enhanced(site_url: str, page_url: str) -> str:
             except Exception:
                 last_crawled = index_status["lastCrawlTime"]
 
-        rich_results = None
-        if "richResultsResult" in inspection:
-            rich = inspection["richResultsResult"]
-            rich_results = {
-                "verdict": rich.get("verdict", "UNKNOWN"),
-                "detected_types": [
-                    item.get("richResultType", "Unknown")
-                    for item in rich.get("detectedItems", [])
-                ],
-                # Issues are nested under detectedItems[].items[].issues[] and the
-                # message key is "issueMessage". Reading a top-level
-                # "richResultsIssues" key -- which the API never returns -- made this
-                # list always empty, hiding every rich-result problem.
-                "issues": [
-                    {
-                        "type": detected.get("richResultType", "Unknown"),
-                        "item": item.get("name"),
-                        "severity": issue.get("severity"),
-                        "message": issue.get("issueMessage"),
-                    }
-                    for detected in rich.get("detectedItems", [])
-                    for item in detected.get("items", [])
-                    for issue in item.get("issues", [])
-                ],
-            }
+        rich_results = _rich_results_summary(inspection)
 
         return json.dumps({
             "page_url": page_url,
@@ -771,20 +780,16 @@ async def batch_url_inspection(site_url: str, urls: str) -> str:
                     except:
                         last_crawl = index_status["lastCrawlTime"]
                 
-                # Check for rich results
-                rich_results = "None"
-                if "richResultsResult" in inspection:
-                    rich = inspection["richResultsResult"]
-                    if rich.get("verdict") == "PASS" and "detectedItems" in rich and rich["detectedItems"]:
-                        rich_types = [item.get("richResultType", "Unknown") for item in rich["detectedItems"]]
-                        rich_results = ", ".join(rich_types)
-                
+                # Rich results, in the same shape inspect_url_enhanced reports.
+                # The old summary only kept the detected type names, and only when
+                # the rich-result verdict was PASS -- so a page Google fails came
+                # back as "None", the one state that reads as "nothing to see here".
                 results.append({
                     "url": page_url,
-                    "verdict": verdict,
+                    "index_verdict": verdict,
                     "coverage_state": coverage,
                     "last_crawled": last_crawl,
-                    "rich_results": rich_results,
+                    "rich_results": _rich_results_summary(inspection),
                 })
 
             except Exception as e:

--- a/gsc_server.py
+++ b/gsc_server.py
@@ -677,9 +677,20 @@ async def inspect_url_enhanced(site_url: str, page_url: str) -> str:
                     item.get("richResultType", "Unknown")
                     for item in rich.get("detectedItems", [])
                 ],
+                # Issues are nested under detectedItems[].items[].issues[] and the
+                # message key is "issueMessage". Reading a top-level
+                # "richResultsIssues" key -- which the API never returns -- made this
+                # list always empty, hiding every rich-result problem.
                 "issues": [
-                    {"severity": issue.get("severity"), "message": issue.get("message")}
-                    for issue in rich.get("richResultsIssues", [])
+                    {
+                        "type": detected.get("richResultType", "Unknown"),
+                        "item": item.get("name"),
+                        "severity": issue.get("severity"),
+                        "message": issue.get("issueMessage"),
+                    }
+                    for detected in rich.get("detectedItems", [])
+                    for item in detected.get("items", [])
+                    for issue in item.get("issues", [])
                 ],
             }
 

--- a/test_gsc_server.py
+++ b/test_gsc_server.py
@@ -484,7 +484,51 @@ class TestBatchUrlInspection(unittest.IsolatedAsyncioTestCase):
             )
         data = json.loads(result)
         self.assertEqual(data["count"], 2)
-        self.assertEqual(data["results"][0]["verdict"], "PASS")
+        self.assertEqual(data["results"][0]["index_verdict"], "PASS")
+
+    async def test_reports_failing_rich_results(self):
+        mod = _load_module()
+        service = _make_service()
+        service.urlInspection().index().inspect().execute.return_value = {
+            "inspectionResult": {
+                "indexStatusResult": {
+                    "verdict": "PASS",
+                    "coverageState": "Submitted and indexed",
+                },
+                "richResultsResult": {
+                    "verdict": "FAIL",
+                    "detectedItems": [
+                        {
+                            "richResultType": "Merchant listings",
+                            "items": [
+                                {
+                                    "name": "Example product",
+                                    "issues": [
+                                        {
+                                            "issueMessage": "Missing field 'image'",
+                                            "severity": "ERROR",
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                },
+            }
+        }
+        with patch("gsc_server.get_gsc_service", return_value=service):
+            result = await mod.batch_url_inspection(
+                "https://example.com/", "https://example.com/page/"
+            )
+        row = json.loads(result)["results"][0]
+        self.assertEqual(row["index_verdict"], "PASS")
+        self.assertEqual(row["rich_results"]["verdict"], "FAIL")
+        self.assertEqual(row["rich_results"]["detected_types"], ["Merchant listings"])
+        self.assertEqual(len(row["rich_results"]["issues"]), 1)
+        self.assertEqual(row["rich_results"]["issues"][0]["severity"], "ERROR")
+        self.assertEqual(
+            row["rich_results"]["issues"][0]["message"], "Missing field 'image'"
+        )
 
     async def test_batch_limit_enforced_at_10_urls(self):
         mod = _load_module()

--- a/test_gsc_server.py
+++ b/test_gsc_server.py
@@ -422,6 +422,42 @@ class TestInspectUrl(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(data["page_url"], "https://example.com/page/")
         self.assertIn("last_crawled", data)
 
+    async def test_reports_rich_result_issues(self):
+        mod = _load_module()
+        service = _make_service()
+        service.urlInspection().index().inspect().execute.return_value = {
+            "inspectionResult": {
+                "indexStatusResult": {"verdict": "PASS"},
+                "richResultsResult": {
+                    "verdict": "PASS",
+                    "detectedItems": [
+                        {
+                            "richResultType": "Merchant listings",
+                            "items": [
+                                {
+                                    "name": "Example product",
+                                    "issues": [
+                                        {
+                                            "issueMessage": "Missing field 'shippingDetails'",
+                                            "severity": "WARNING",
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                },
+            }
+        }
+        with patch("gsc_server.get_gsc_service", return_value=service):
+            result = await mod.inspect_url_enhanced("https://example.com/", "https://example.com/page/")
+        issues = json.loads(result)["rich_results"]["issues"]
+        self.assertEqual(len(issues), 1)
+        self.assertEqual(issues[0]["severity"], "WARNING")
+        self.assertEqual(issues[0]["message"], "Missing field 'shippingDetails'")
+        self.assertEqual(issues[0]["type"], "Merchant listings")
+        self.assertEqual(issues[0]["item"], "Example product")
+
 
 # ---------------------------------------------------------------------------
 # TestBatchUrlInspection


### PR DESCRIPTION
Fixes #48.

`batch_url_inspection` built its `rich_results` field from the detected type names only, and only when the rich results verdict was `PASS`. Every other verdict fell through to the literal string `"None"`, the one value a caller reads as "nothing detected, nothing to worry about". The verdict and the whole issues array never left the function. The row also labelled the indexing verdict plainly `verdict`, sitting next to `rich_results` as its peer, so `"verdict": "PASS"` read as a clean bill of health for the page as a whole.

The result is that the tool most likely to be used for monitoring many URLs at once reports pages as fine while Google is failing them.

## Change

`inspect_url_enhanced` already shapes `richResultsResult` correctly. That block moves into `_rich_results_summary()` and both tools call it, so the two cannot report different things about the same page again. The batch row keeps its compact shape and renames `verdict` to `index_verdict`.

## Verified against the live API

Property `sc-domain:multi-profi.com`, URL `https://multi-profi.com/produkt/multi-profi-spezialreiniger22multi-profi-bodenreiniger`, a service account with `webmasters.readonly`, same URL and same minute for both tools.

Before, `batch_url_inspection`:

```json
{
  "url": "https://multi-profi.com/produkt/multi-profi-spezialreiniger22multi-profi-bodenreiniger",
  "verdict": "PASS",
  "coverage_state": "Submitted and indexed",
  "last_crawled": "2026-09-01",
  "rich_results": "None"
}
```

After, `batch_url_inspection` (14 issues in total, 8 of them severity ERROR, truncated here for length):

```json
{
  "url": "https://multi-profi.com/produkt/multi-profi-spezialreiniger22multi-profi-bodenreiniger",
  "index_verdict": "PASS",
  "coverage_state": "Submitted and indexed",
  "last_crawled": "2026-09-01",
  "rich_results": {
    "verdict": "FAIL",
    "detected_types": ["Product snippets", "Merchant listings"],
    "issues": [
      {"type": "Product snippets", "item": "Multi-Profi Bodenreiniger", "severity": "WARNING", "message": "Missing field \"review\""},
      {"type": "Product snippets", "item": "Multi-Profi Bodenreiniger", "severity": "WARNING", "message": "Missing field \"aggregateRating\""},
      {"type": "Merchant listings", "item": "Multi-Profi Bodenreiniger — HA-Lin-00004", "severity": "ERROR", "message": "Missing field \"image\""},
      {"type": "Merchant listings", "item": "Multi-Profi Bodenreiniger — HA-Lin-00004", "severity": "ERROR", "message": "Missing field \"size\""}
    ]
  }
}
```

That now matches what `inspect_url_enhanced` returns for the same URL, field for field.

## Notes

This is the batch path twin of #46. That one hid the issues inside a correct structure, this one dropped the structure too, so both tools now go through one function instead of two copies that can drift apart.

Stacked on #47, which carries the first commit here. Once #47 lands this narrows to the second commit.

`index_verdict` renames a response key, so it is a breaking change for anything reading `results[].verdict` from this tool. The name is the point of the fix, and the response of `inspect_url_enhanced` is untouched.
